### PR TITLE
Automatycznie generuj czytelną datę następnego wydarzenia.

### DIFF
--- a/_includes/date.txt
+++ b/_includes/date.txt
@@ -1,0 +1,35 @@
+{% if include.lang == "en" %}
+    {{ include.time_arg | date: "%A" }},
+    {{ include.time_arg | date_to_long_string }}
+    ({{ include.time_arg | date: "%R" }})
+{% elsif include.lang == "pl" %}
+    {% assign weekday=include.time_arg | date: "%w" %}
+    {% assign month=include.time_arg | date: "%m" %}
+    {% case weekday %}{%
+        when '0' %}niedzielę{%
+        when '1' %}poniedziałek{%
+        when '2' %}wtorek{%
+        when '3' %}środę{%
+        when '4' %}czwartek{%
+        when '5' %}piątek{%
+        when '6' %}sobotę{%
+    endcase %},
+    {{ include.time_arg | date: "%d" }}
+    {% case month %}{%
+    when '01' %}stycznia{%
+    when '02' %}lutego{%
+    when '03' %}marca{%
+    when '04' %}kwietnia{%
+    when '05' %}maja{%
+    when '06' %}czerwca{%
+    when '07' %}lipca{%
+    when '08' %}sierpnia{%
+    when '09' %}września{%
+    when '10' %}października{%
+    when '11' %}listopada{%
+    when '12' %}grudnia{%
+    endcase %}
+    {{ include.time_arg | date: "%Y" }}
+    o godzinie
+    {{ include.time_arg | date: "%R" }}
+{% endif %}

--- a/_includes/next_meeting.txt
+++ b/_includes/next_meeting.txt
@@ -1,2 +1,3 @@
-{% assign next_meeting = 10 %}
+{% assign next_meeting = "10-3-2020 17:00" %}
+{% assign next_meeting_location = "Opus. Centrum Promocji i Rozwoju Inicjatyw Obywatelskich (Prez. Gabriela Narutowicz 8/10)" %}
 {% assign next_meeting_url = "https://www.meetup.com/Hakierspejs-Łodź/events/269000997" %}

--- a/en.html
+++ b/en.html
@@ -8,7 +8,7 @@
     <h1 class="cover-heading">We're building a <a href="https://en.m.wikipedia.org/wiki/Hackerspace">Hackerspace</a> in Łódź. We're looking for people.</h1>
 
     <div class="alert alert-danger" style="text-shadow: none !important">
-    📅 <strong>Next meeting:</strong> March {{ next_meeting }} (Tuesday). See you at 17:00 in Centrum Opus (Narutowicza 8/10 street). We're starting early, but it's OK if you arrive later :)
+    📅 <strong>Next meeting:</strong> {% include date.txt time_arg=next_meeting lang="en" %} at {{ next_meeting_location }}. We're starting early, but it's OK if you arrive later :)
        (see more info at <u><a class="text-danger" href="{{ next_meeting_url }}">meetup.com</a></u>)
     </div>
 

--- a/index.html
+++ b/index.html
@@ -8,8 +8,9 @@
     <h1 class="cover-heading">Budujemy <a href="https://pl.m.wikipedia.org/wiki/Hackerspace">Hackerspace</a> w Łodzi. Szukamy ludzi.</h1>
 
     <div class="alert alert-danger" style="text-shadow: none !important">
-    📅 <strong>Następne spotkanie:</strong> {{ next_meeting }} marca (wtorek) o godzinie 17:00 w Centrum Opus (Narutowicza 8/10). Zaczynamy wcześnie, ale nie ma problemu jeśli dołączysz później :)
-       (więcej info na <u><a class="text-danger" href="{{ next_meeting_url }}">meetup.com</a></u>)
+    📅 <strong>Następne spotkanie:</strong> {% include date.txt time_arg=next_meeting lang="pl" %} w: {{ next_meeting_location }}.
+         Zaczynamy wcześnie, ale nie ma problemu jeśli dołączysz później :)
+       Więcej info na <u><a class="text-danger" href="{{ next_meeting_url }}">meetup.com</a></u>.
     </div>
 
     <!--


### PR DESCRIPTION
Będzie trochę brzydziej, ale przynajmniej da się to zautomatyzować. Zmienia się rendering pola "następne spotkanie". Wcześniej wyglądał tak:

![image](https://user-images.githubusercontent.com/295322/76161674-df8de200-6135-11ea-81a3-af51fe90cb64.png)
![image](https://user-images.githubusercontent.com/295322/76161680-ed436780-6135-11ea-9dcd-305b15b86d08.png)

Po zmianie będzie wyglądać tak:

![image](https://user-images.githubusercontent.com/295322/76161688-fc2a1a00-6135-11ea-9cda-449736410f4b.png)
![image](https://user-images.githubusercontent.com/295322/76161693-08ae7280-6136-11ea-8b43-38f54dd8c1b9.png)