### PR TITLE
Różnorodność -> różnice

### DIFF
--- a/manifesto.html
+++ b/manifesto.html
@@ -30,7 +30,7 @@
     </p>
 
     <p class="lead">
-      Jeżeli zauwafżysz niewłaściwe zachowanie lub poczujesz się zagrożony daj znać zarządowi
+      Jeżeli zauważysz niewłaściwe zachowanie lub poczujesz się zagrożony daj znać zarządowi
       osobiście lub anonimowo. Załatwimy to. Najważniejsze jest dla nas to, żeby każda 
       osoba czuła się dobrze.
     </p>

--- a/manifesto.html
+++ b/manifesto.html
@@ -13,7 +13,7 @@
     </p>
 
     <p class="lead">
-        Ta różnorodność sprawia, że dzięki różnym perspektywom i współpracy
+        Te różnice sprawiają, że dzięki różnym perspektywom i współpracy
         potrafimy rozwiązać wiele problemów. Jednocześnie, jako, że
         wiele ze wspomnianych cech nie jest naszym wyborem, a wręcz jest poza
         naszą kontrolą, mogą one być czułym punktem, dlatego <em>bardzo ważne
@@ -30,7 +30,7 @@
     </p>
 
     <p class="lead">
-      Jeżeli zauważysz niewłaściwe zachowanie lub poczujesz się zagrożony daj znać zarządowi
+      Jeżeli zauwafżysz niewłaściwe zachowanie lub poczujesz się zagrożony daj znać zarządowi
       osobiście lub anonimowo. Załatwimy to. Najważniejsze jest dla nas to, żeby każda 
       osoba czuła się dobrze.
     </p>


### PR DESCRIPTION
Uzasadnienie:
Ktoś zgłaszał, że "różnorodność" może kojarzyć się politycznie. Nie wiem, ale chyba "różnice" są bardziej neutralne. A nie wydaje mi się, by to było w jakiś sposób niepoprawne czy niezgodne z rzeczywistością określenie.

Rozwijając temat, bo na forum chyba zostałem źle zrozumiany:
Nie chodzi mi o to, by każde nacechowane politycznie słowo zastępować nienacechowanym politycznie odpowiednikiem. Bo to jest niewykonalne. Ale każda taka zmiana przybliża nas do sytuacji, w której manifest będzie możliwie najmniej nacechowany politycznie, a to wpływa pozytywnie na inkluzywność. Nikt nie będzie się bał do nas dołączać patrząc, że angażujemy się w jakieś polityczne spory czy wojny, i to jeszcze od jednej konkretnej strony. Dobrze, może nie nikt, bo to jest utopia – ale bliżej tej utopijnej sytuacji będziemy, i to dla mnie jest zdecydowany pozytyw.
 
Innym takim pojęciem jest 'ksenofobia', i tam chodzi o więcej – nie tylko o nacechowanie polityczne, ale przede wszystkim o to, że to specjalistyczne, mało znane słowo, które może być źle rozumiane (co, w sumie, jeszcze podbija to polityczne nacechowanie). Ale o tym będzie osobny PR.