### PR TITLE
Dodanie odstępu pod nagłówkiem "Galeria"

### DIFF
--- a/assets/styles/custom.css
+++ b/assets/styles/custom.css
@@ -107,6 +107,10 @@ nav ul li .bi {
   color: var(--dark-color);
 }
 
+.fotorama {
+  margin-top: 0.5em;
+}
+
 /*
  * #isitopen is a container for message that is shown
  * when there are people hacking physically in the hackerspace.


### PR DESCRIPTION
Pod pozostałymi nagłówkami są odstępy (realizowane jako margin-top jako styl przypisany np. do elementu P), przy galerii tego brakuje.