### PR TITLE
Wycięcie linku do IRC

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@ layout: default
     <p>Żeby do nas dołączyć, wejdź na naszego chata przez jeden z komunikatorów (wszystkie prowadzą do tego samego chata).</p>
     <p>
     <a class="button" href="//t.me/joinchat/K73_2BVhRxP6nb4I81YIPQ" title="przenosi na inną stronę - czat Telegram">{% include icons/chat-left.html %}Telegram</a>
-    <a class="button" href="//web.libera.chat/#hakierspejs" title="przenosi na inną stronę - czat IRC">{% include icons/chat-center.html %}IRC</a>
+    <!-- <a class="button" href="//web.libera.chat/#hakierspejs" title="przenosi na inną stronę - czat IRC">{% include icons/chat-center.html %}IRC</a> -->
     <a class="button" href="//app.element.io/#/room/#hs-ldz:hackerspace.pl" title="przenosi na inną stronę - czat Matrix">{% include icons/chat-right.html %}Matrix</a>
     </p>
 


### PR DESCRIPTION
Proponuję tymczasowo (dlatego wzięte w komentarz) wyciąć link do IRC-a na stronie głównej. Po odcięciu IRC-a od bridge'a, ten jest martwy, a przez długi czas nikt nie miał czasu (ja, biję się w pierś, też) żeby coś z tym bridge'em zrobić. Bez sensu reklamować na stronie IRC-a na którym nic się nie dzieje i jest ryzyko, że wbijająca osoba długo nie otrzyma żadnej odpowiedzi, po czym po prostu wyjdzie.