### PR TITLE
Add link to Mastodon in footer.html.

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -7,6 +7,7 @@
   | <a href="//grafana.hs-ldz.pl" title="przenosi na inną stronę - wykresy opisujące metryki związane z organizacją">grafana</a>
   | <a href="//github.com/hakierspejs" title="przenosi na inną stronę - repozytorium kodu stowarzyszenia">git</a>
   | <a href="//github.com/hakierspejs/wiki/wiki" title="przenosi na inną stronę - Wiki stowarzyszenia">wiki</a>
+  | <a rel="me" href="https://mas.to/@hslodz" title="przenosi na inną stronę - profil stowarzyszenia na Mastodonie">mastodon</a>
   | <a href="/feed.xml" title="rss">rss</a>
 </p>
 <p lang="en">


### PR DESCRIPTION
This will enable us to use verification feature that's built into Mastodon and will redirect people coming from Mastodon/Fediverse to the website of Hackerspace. 